### PR TITLE
Add reusable fanzine grid view widget

### DIFF
--- a/lib/pages/register_page.dart
+++ b/lib/pages/register_page.dart
@@ -1,5 +1,7 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import '../widgets/register_widget.dart';
+import '../utils/fanzine_grid_view.dart';
 
 class RegisterPage extends StatelessWidget {
   final void Function()? onTap;
@@ -8,62 +10,52 @@ class RegisterPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-
     return Scaffold(
       backgroundColor: Colors.grey[200],
       body: SafeArea(
-        child: GridView.count(
-          crossAxisCount: 2,
-          padding: const EdgeInsets.all(8.0),
-          mainAxisSpacing: 8.0,
-          crossAxisSpacing: 8.0,
-          childAspectRatio: 5 / 8,
-          children: <Widget>[
-            Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(12),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withOpacity(0.1),
-                    spreadRadius: 1,
-                    blurRadius: 5,
-                    offset: const Offset(0, 3),
+        child: StreamBuilder<DocumentSnapshot>(
+          stream: FirebaseFirestore.instance
+              .collection('app_settings')
+              .doc('main_settings')
+              .snapshots(),
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (!snapshot.hasData || !snapshot.data!.exists) {
+              return const Center(child: Text('Settings not found.'));
+            }
+            final data = snapshot.data!.data() as Map<String, dynamic>;
+            final shortCode = data['register_zine_shortcode'] as String?;
+            if (shortCode == null) {
+              return const Center(child: Text('No register zine configured.'));
+            }
+            return FanzineGridView(
+              shortCode: shortCode,
+              uiWidget: Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(12),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.1),
+                      spreadRadius: 1,
+                      blurRadius: 5,
+                      offset: const Offset(0, 3),
+                    ),
+                  ],
+                ),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(12.0),
+                  child: RegisterWidget(
+                    onTap: onTap,
                   ),
-                ],
-              ),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(12.0),
-                child: RegisterWidget(
-                  onTap: onTap,
                 ),
               ),
-            ),
-
-            _buildImagePlaceholder(Colors.blueGrey, 'Image 1'),
-            _buildImagePlaceholder(Colors.teal, 'Image 2'),
-            _buildImagePlaceholder(Colors.amber, 'Image 3'),
-            _buildImagePlaceholder(Colors.deepOrange, 'Image 4'),
-            _buildImagePlaceholder(Colors.purple, 'Image 5'),
-          ],
-        ),
-      ),
-    );
-  }
-
-  // Helper widget for image placeholders (same as in LoginPage)
-  Widget _buildImagePlaceholder(Color color, String text) {
-    // This container will be forced into the 5/8 aspect ratio by the GridView
-    return Container(
-      decoration: BoxDecoration(
-        color: color,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Center(
-        child: Text(
-          text,
-          style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+            );
+          },
         ),
       ),
     );
   }
 }
+

--- a/lib/utils/fanzine_grid_view.dart
+++ b/lib/utils/fanzine_grid_view.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class FanzineGridView extends StatelessWidget {
+  final String shortCode;
+  final Widget uiWidget;
+
+  const FanzineGridView({
+    super.key,
+    required this.shortCode,
+    required this.uiWidget,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<QuerySnapshot>(
+      stream: FirebaseFirestore.instance
+          .collection('fanzines')
+          .where('shortCode', isEqualTo: shortCode)
+          .limit(1)
+          .snapshots(),
+      builder: (context, fanzineSnapshot) {
+        if (fanzineSnapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (!fanzineSnapshot.hasData || fanzineSnapshot.data!.docs.isEmpty) {
+          return const Center(child: Text('Fanzine not found.'));
+        }
+
+        final fanzineId = fanzineSnapshot.data!.docs.first.id;
+
+        return StreamBuilder<QuerySnapshot>(
+          stream: FirebaseFirestore.instance
+              .collection('fanzines')
+              .doc(fanzineId)
+              .collection('pages')
+              .orderBy('pageNumber')
+              .snapshots(),
+          builder: (context, pagesSnapshot) {
+            if (pagesSnapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (pagesSnapshot.hasError) {
+              return const Center(child: Text('Error loading pages.'));
+            }
+
+            final pages = pagesSnapshot.data?.docs ?? [];
+
+            return GridView.builder(
+              padding: const EdgeInsets.all(8.0),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 2,
+                childAspectRatio: 5 / 8,
+                mainAxisSpacing: 8.0,
+                crossAxisSpacing: 8.0,
+              ),
+              itemCount: pages.length + 1,
+              itemBuilder: (context, index) {
+                if (index == 0) {
+                  return uiWidget;
+                }
+                final page = pages[index - 1];
+                final data = page.data() as Map<String, dynamic>;
+                final imageUrl = data['imageUrl'] ?? '';
+                return ClipRRect(
+                  borderRadius: BorderRadius.circular(12.0),
+                  child: imageUrl.isNotEmpty
+                      ? Image.network(imageUrl, fit: BoxFit.cover)
+                      : Container(color: Colors.grey[300]),
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- add FanzineGridView utility to show two-column grid of fanzine pages with a custom first cell
- use FanzineGridView on RegisterPage, pulling shortcode from app settings and showing RegisterWidget as the first cell

## Testing
- `dart format lib/utils/fanzine_grid_view.dart lib/pages/register_page.dart` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689be774538c832ba23147638b301c5b