### PR TITLE
Use FanzineGridView on fanzine page

### DIFF
--- a/lib/pages/fanzine_page.dart
+++ b/lib/pages/fanzine_page.dart
@@ -1,4 +1,8 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+
+import '../utils/fanzine_grid_view.dart';
 import '../widgets/fanzine_widget.dart';
 
 class FanzinePage extends StatelessWidget {
@@ -6,58 +10,56 @@ class FanzinePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final currentUser = FirebaseAuth.instance.currentUser;
+    if (currentUser == null) {
+      return const Scaffold(
+        body: Center(child: Text('User not logged in.')),
+      );
+    }
 
     return Scaffold(
       backgroundColor: Colors.grey[200],
       body: SafeArea(
-        child: GridView.count(
-          crossAxisCount: 2,
-          padding: const EdgeInsets.all(8.0),
-          mainAxisSpacing: 8.0,
-          crossAxisSpacing: 8.0,
-          childAspectRatio: 5 / 8,
-          children: <Widget>[
-            Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(12),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withOpacity(0.1),
-                    spreadRadius: 1,
-                    blurRadius: 5,
-                    offset: const Offset(0, 3),
-                  ),
-                ],
-              ),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(12.0),
-                child: const FanzineWidget(),
-              ),
-            ),
+        child: StreamBuilder<DocumentSnapshot>(
+          stream: FirebaseFirestore.instance
+              .collection('Users')
+              .doc(currentUser.email)
+              .snapshots(),
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (!snapshot.hasData || !snapshot.data!.exists) {
+              return const Center(child: Text('User not found.'));
+            }
 
-            _buildImagePlaceholder(Colors.blueGrey, 'Image 1'),
-            _buildImagePlaceholder(Colors.teal, 'Image 2'),
-            _buildImagePlaceholder(Colors.amber, 'Image 3'),
-            _buildImagePlaceholder(Colors.deepOrange, 'Image 4'),
-            _buildImagePlaceholder(Colors.purple, 'Image 5'),
-          ],
-        ),
-      ),
-    );
-  }
+            final data = snapshot.data!.data() as Map<String, dynamic>;
+            final shortCode = data['newFanzine'] as String?;
+            if (shortCode == null) {
+              return const Center(child: Text('No fanzine configured.'));
+            }
 
-  // Helper widget for image placeholders (same as in LoginPage)
-  Widget _buildImagePlaceholder(Color color, String text) {
-    // This container will be forced into the 5/8 aspect ratio by the GridView
-    return Container(
-      decoration: BoxDecoration(
-        color: color,
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Center(
-        child: Text(
-          text,
-          style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
+            return FanzineGridView(
+              shortCode: shortCode,
+              uiWidget: Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(12),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.1),
+                      spreadRadius: 1,
+                      blurRadius: 5,
+                      offset: const Offset(0, 3),
+                    ),
+                  ],
+                ),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(12.0),
+                  child: const FanzineWidget(),
+                ),
+              ),
+            );
+          },
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- Render fanzine pages with FanzineGridView on fanzine page
- Load user fanzine short code from Users collection
- Place FanzineWidget in first grid cell

## Testing
- `dart format lib/pages/fanzine_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689beeda598c832bb1c64c09197af371