### PR TITLE
Add slug resolver routing and deep link scaffolding

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,12 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https" android:host="bqopd.com"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.developer.associated-domains</key>
+  <array>
+    <string>applinks:bqopd.com</string>
+  </array>
+</dict>
+</plist>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,12 @@
 import 'package:bqopd/firebase_options.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'auth/auth.dart';
 import 'auth/login_or_register.dart';
 import 'pages/fanzine_page.dart';
+import 'pages/not_found_page.dart';
+import 'pages/resolver_page.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -16,16 +19,31 @@ void main() async {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
+  static final GoRouter _router = GoRouter(
+    errorBuilder: (context, state) => const NotFoundPage(),
+    routes: [
+      GoRoute(path: '/', builder: (context, state) => const AuthPage()),
+      GoRoute(path: '/auth', builder: (context, state) => const AuthPage()),
+      GoRoute(
+          path: '/login_register_page',
+          builder: (context, state) => const LoginOrRegister()),
+      GoRoute(
+          path: '/fanzine_page',
+          builder: (context, state) => const FanzinePage()),
+      GoRoute(
+        path: '/:slug',
+        builder: (context, state) =>
+            ResolverPage(slug: state.pathParameters['slug']!),
+      ),
+    ],
+  );
+
   @override
   Widget build(BuildContext context) {
     return SafeArea(
-      child: MaterialApp(
+      child: MaterialApp.router(
         debugShowCheckedModeBanner: false,
-        home: const AuthPage(),
-        routes: {
-          '/login_register_page': (context) => const LoginOrRegister(),
-          '/fanzine_page': (context) => const FanzinePage(),
-        },
+        routerConfig: _router,
       ),
     );
   }

--- a/lib/pages/not_found_page.dart
+++ b/lib/pages/not_found_page.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+class NotFoundPage extends StatelessWidget {
+  const NotFoundPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('404 - Page not found')),
+    );
+  }
+}

--- a/lib/pages/resolver_page.dart
+++ b/lib/pages/resolver_page.dart
@@ -1,0 +1,59 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import 'not_found_page.dart';
+
+final RegExp _shortcodeRegExp = RegExp(r'^[0-9A-HJKMNP-TV-Z]{7}$');
+
+class ResolverPage extends StatefulWidget {
+  final String slug;
+  const ResolverPage({super.key, required this.slug});
+
+  @override
+  State<ResolverPage> createState() => _ResolverPageState();
+}
+
+class _ResolverPageState extends State<ResolverPage> {
+  bool _notFound = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _resolve();
+  }
+
+  Future<void> _resolve() async {
+    final firestore = FirebaseFirestore.instance;
+    final slug = widget.slug;
+    DocumentSnapshot<Map<String, dynamic>> snap;
+    if (_shortcodeRegExp.hasMatch(slug)) {
+      snap = await firestore.doc('codes/$slug').get();
+    } else {
+      snap = await firestore.doc('aliases/${slug.toLowerCase()}').get();
+    }
+    if (!snap.exists) {
+      setState(() => _notFound = true);
+      return;
+    }
+    final data = snap.data()!;
+    final type = data['type'] as String?;
+    final targetRef = data['targetRef'] as String?;
+    if (type == 'fanzine' && targetRef != null) {
+      if (!mounted) return;
+      context.go('/fanzine_page');
+    } else {
+      setState(() => _notFound = true);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_notFound) {
+      return const NotFoundPage();
+    }
+    return const Scaffold(
+      body: Center(child: CircularProgressIndicator()),
+    );
+  }
+}

--- a/lib/utils/auth_gate.dart
+++ b/lib/utils/auth_gate.dart
@@ -1,0 +1,18 @@
+import 'dart:convert';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+
+Future<void> guardWrite(BuildContext ctx, Future<void> Function() doIt,
+    {required String currentUrl, required String action}) async {
+  if (FirebaseAuth.instance.currentUser == null) {
+    final payload =
+        base64Url.encode(utf8.encode('{"url":"$currentUrl","action":"$action"}'));
+    if (ctx.mounted) {
+      ctx.go('/auth?return=$payload');
+    }
+    return;
+  }
+  await doIt();
+}

--- a/lib/utils/qr_helper.dart
+++ b/lib/utils/qr_helper.dart
@@ -1,0 +1,14 @@
+import 'package:qr_flutter/qr_flutter.dart';
+
+const String qrUrlPrefix = 'https://bqopd.com/';
+const int qrVersion = 4; // adjust between 3 or 4 as needed
+const QrErrorCorrectLevel qrEcc = QrErrorCorrectLevel.M;
+
+QrImageView buildQr(String shortcode, {double size = 200}) {
+  return QrImageView(
+    data: '$qrUrlPrefix$shortcode',
+    version: qrVersion,
+    errorCorrectionLevel: qrEcc,
+    size: size,
+  );
+}

--- a/lib/utils/shortcode_generator.dart
+++ b/lib/utils/shortcode_generator.dart
@@ -1,64 +1,45 @@
 import 'dart:math';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
-const String _base62Chars =
-    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+const String _crockford32Chars =
+    '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
 
 String generateShortcode() {
   final random = Random();
-  String shortcode = '';
+  final StringBuffer shortcode = StringBuffer();
   for (int i = 0; i < 7; i++) {
-    shortcode += _base62Chars[random.nextInt(_base62Chars.length)];
+    shortcode.write(
+        _crockford32Chars[random.nextInt(_crockford32Chars.length)]);
   }
-  return shortcode;
+  return shortcode.toString();
 }
 
-// Note: FirebaseFirestore is not directly imported here.
-// It's assumed that the calling code (e.g., in image_upload_modal.dart)
-// will handle the Firestore instance and calls.
-// This function provides the logic but expects a Firestore instance.
-//
-// To use this function, you would typically do something like:
-//
-// import 'package:cloud_firestore/cloud_firestore.dart';
-// FirebaseFirestore firestore = FirebaseFirestore.instance;
-// String? newShortcode = await assignShortcode(firestore, 'image', 'your_image_id');
+Future<void> reserveShortcode(FirebaseFirestore firestore, String code,
+    Map<String, dynamic> data) async {
+  final ref = firestore.doc('codes/$code');
+  await firestore.runTransaction((tx) async {
+    final snap = await tx.get(ref);
+    if (snap.exists) {
+      throw Exception('Shortcode already exists');
+    }
+    tx.set(ref, data);
+  });
+}
 
 Future<String?> assignShortcode(
-    dynamic firestoreInstance, String contentType, String contentId) async {
-  // It's better to type firestoreInstance as FirebaseFirestore
-  // but to avoid direct dependency here, we use dynamic.
-  // Ensure you pass a valid FirebaseFirestore instance.
-
-  String shortcode;
-  bool isUnique = false;
-  int retries = 0;
-  const int maxRetries = 10; // To prevent infinite loops in rare cases
-
-  while (!isUnique && retries < maxRetries) {
-    shortcode = generateShortcode();
-    final docRef = firestoreInstance.collection('shortcodes').doc(shortcode);
-    final docSnapshot = await docRef.get();
-
-    if (!docSnapshot.exists) {
-      isUnique = true;
-      try {
-        await docRef.set({
-          'type': contentType,
-          'contentId': contentId,
-          'createdAt': FieldValue.serverTimestamp(), // Uses Firestore server timestamp
-        });
-        return shortcode;
-      } catch (e) {
-        // Handle potential errors during Firestore write
-        print('Error assigning shortcode: $e');
-        return null;
-      }
+    FirebaseFirestore firestore, String type, String targetRef) async {
+  for (int i = 0; i < 10; i++) {
+    final code = generateShortcode();
+    try {
+      await reserveShortcode(firestore, code, {
+        'type': type,
+        'targetRef': targetRef,
+        'createdAt': FieldValue.serverTimestamp(),
+      });
+      return code;
+    } catch (_) {
+      continue;
     }
-    retries++;
   }
-  if (retries >= maxRetries) {
-    print('Failed to generate a unique shortcode after $maxRetries retries.');
-  }
-  return null; // Failed to find a unique shortcode
+  return null;
 }

--- a/lib/utils/slug_validators.dart
+++ b/lib/utils/slug_validators.dart
@@ -1,0 +1,32 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+final RegExp shortcodeRegExp = RegExp(r'^[0-9A-HJKMNP-TV-Z]{7}$');
+final RegExp aliasRegExp = RegExp(r'^[A-Za-z0-9-]{3,39}$');
+const Set<String> reserved = {
+  'admin',
+  'login',
+  'auth',
+  'api',
+  'about',
+  'terms',
+  'privacy',
+};
+
+Future<void> claimUsername(FirebaseFirestore db, String username) async {
+  final lower = username.toLowerCase();
+  if (shortcodeRegExp.hasMatch(username)) {
+    throw Exception('Username cannot be a shortcode');
+  }
+  if (!aliasRegExp.hasMatch(username)) {
+    throw Exception('Invalid username');
+  }
+  if (reserved.contains(lower)) {
+    throw Exception('Reserved username');
+  }
+  final ref = db.doc('aliases/$lower');
+  final snap = await ref.get();
+  if (snap.exists) {
+    throw Exception('Alias already exists');
+  }
+  await ref.set({'createdAt': FieldValue.serverTimestamp()});
+}

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "TEAMID.com.example.bqopd",
+        "paths": ["/*"]
+      }
+    ]
+  }
+}

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,10 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.example.bqopd",
+      "sha256_cert_fingerprints": ["YOUR_SHA256_FINGERPRINT"]
+    }
+  }
+]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,8 @@ dependencies:
   flutter_lints: ^5.0.0
   file_picker: ^10.0.0
   nanoid2: ^2.0.0
+  go_router: ^14.2.1
+  qr_flutter: ^4.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- route prefixless paths through new ResolverPage
- add shortcode/alias validators and QR helper
- scaffold deep link configuration for Android, iOS, and web

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689c07e63928832b8ca28122e515bb70