### PR TITLE
feat: add auth return flow

### DIFF
--- a/lib/core/guard_write.dart
+++ b/lib/core/guard_write.dart
@@ -1,0 +1,25 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import 'return_intent.dart';
+import 'router_utils.dart';
+
+ReturnIntent? _pendingIntent;
+
+Future<T?> guardWrite<T>(BuildContext ctx, Future<T> Function() doWrite,
+    {required String action, Map<String, String>? extras}) async {
+  if (FirebaseAuth.instance.currentUser != null) {
+    return await doWrite();
+  }
+  final intent = ReturnIntent(url: currentUrl(ctx), action: action, extras: extras);
+  _pendingIntent = intent;
+  ctx.go('/auth?return=${Uri.encodeComponent(intent.encode())}');
+  return null;
+}
+
+ReturnIntent? consumePendingIntent() {
+  final intent = _pendingIntent;
+  _pendingIntent = null;
+  return intent;
+}

--- a/lib/core/return_intent.dart
+++ b/lib/core/return_intent.dart
@@ -1,0 +1,29 @@
+import 'dart:convert';
+
+class ReturnIntent {
+  final String url;
+  final String? action;
+  final Map<String, String>? extras;
+
+  ReturnIntent({required this.url, this.action, this.extras});
+
+  String encode() {
+    final map = <String, dynamic>{'url': url};
+    if (action != null) map['action'] = action;
+    if (extras != null && extras!.isNotEmpty) map['extras'] = extras;
+    final jsonStr = jsonEncode(map);
+    return base64Url.encode(utf8.encode(jsonStr));
+  }
+
+  static ReturnIntent decode(String encoded) {
+    final jsonStr = utf8.decode(base64Url.decode(encoded));
+    final Map<String, dynamic> map = jsonDecode(jsonStr);
+    final extras = (map['extras'] as Map?)
+        ?.map((key, value) => MapEntry(key.toString(), value.toString()));
+    return ReturnIntent(
+      url: map['url'] as String,
+      action: map['action'] as String?,
+      extras: extras?.cast<String, String>(),
+    );
+  }
+}

--- a/lib/core/router_utils.dart
+++ b/lib/core/router_utils.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+
+String currentUrl(BuildContext context) {
+  return GoRouter.of(context).location;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,7 @@
 import 'package:bqopd/firebase_options.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
-import 'auth/auth.dart';
-import 'auth/login_or_register.dart';
-import 'pages/fanzine_page.dart';
-import 'pages/not_found_page.dart';
-import 'pages/resolver_page.dart';
+import 'router.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -19,31 +14,12 @@ void main() async {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  static final GoRouter _router = GoRouter(
-    errorBuilder: (context, state) => const NotFoundPage(),
-    routes: [
-      GoRoute(path: '/', builder: (context, state) => const AuthPage()),
-      GoRoute(path: '/auth', builder: (context, state) => const AuthPage()),
-      GoRoute(
-          path: '/login_register_page',
-          builder: (context, state) => const LoginOrRegister()),
-      GoRoute(
-          path: '/fanzine_page',
-          builder: (context, state) => const FanzinePage()),
-      GoRoute(
-        path: '/:slug',
-        builder: (context, state) =>
-            ResolverPage(slug: state.pathParameters['slug']!),
-      ),
-    ],
-  );
-
   @override
   Widget build(BuildContext context) {
     return SafeArea(
       child: MaterialApp.router(
         debugShowCheckedModeBanner: false,
-        routerConfig: _router,
+        routerConfig: router,
       ),
     );
   }

--- a/lib/pages/auth_page.dart
+++ b/lib/pages/auth_page.dart
@@ -1,0 +1,74 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../core/return_intent.dart';
+import '../widgets/login_widget.dart';
+import '../widgets/register_widget.dart';
+
+class AuthPage extends StatefulWidget {
+  final String returnParam;
+  final String? mode;
+  const AuthPage({super.key, required this.returnParam, this.mode});
+
+  @override
+  State<AuthPage> createState() => _AuthPageState();
+}
+
+class _AuthPageState extends State<AuthPage> {
+  late bool _showLogin;
+  bool _handled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _showLogin = widget.mode != 'register';
+  }
+
+  void _toggle() {
+    setState(() {
+      _showLogin = !_showLogin;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: StreamBuilder<User?>(
+        stream: FirebaseAuth.instance.authStateChanges(),
+        builder: (context, snapshot) {
+          if (snapshot.data != null && !_handled) {
+            _handled = true;
+            final intent = ReturnIntent.decode(widget.returnParam);
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              context.go(intent.url);
+            });
+            return const SizedBox.shrink();
+          }
+          return Column(
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  TextButton(
+                    onPressed: () => setState(() => _showLogin = true),
+                    child: const Text('Login'),
+                  ),
+                  TextButton(
+                    onPressed: () => setState(() => _showLogin = false),
+                    child: const Text('Register'),
+                  ),
+                ],
+              ),
+              Expanded(
+                child: _showLogin
+                    ? LoginWidget(onTap: _toggle)
+                    : RegisterWidget(onTap: _toggle),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -1,0 +1,28 @@
+import 'package:go_router/go_router.dart';
+import 'pages/auth_page.dart';
+import 'pages/fanzine_page.dart';
+import 'pages/not_found_page.dart';
+import 'pages/resolver_page.dart';
+
+final router = GoRouter(
+  errorBuilder: (context, state) => const NotFoundPage(),
+  routes: [
+    GoRoute(path: '/', builder: (context, state) => const FanzinePage()),
+    GoRoute(
+      path: '/auth',
+      builder: (context, state) {
+        final ret = state.uri.queryParameters['return'];
+        if (ret == null) {
+          return const NotFoundPage();
+        }
+        final mode = state.uri.queryParameters['mode'];
+        return AuthPage(returnParam: ret, mode: mode);
+      },
+    ),
+    GoRoute(
+      path: '/:slug',
+      builder: (context, state) =>
+          ResolverPage(slug: state.pathParameters['slug']!),
+    ),
+  ],
+);

--- a/lib/widgets/image_view_modal.dart
+++ b/lib/widgets/image_view_modal.dart
@@ -1,4 +1,8 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+
+import '../core/guard_write.dart';
 
 class ImageViewModal extends StatefulWidget {
   final String imageUrl;
@@ -21,6 +25,7 @@ class _ImageViewModalState extends State<ImageViewModal> {
   bool _showComments = false;
   bool _showText = false;
   bool _showShortCode = false;
+  final TextEditingController _commentController = TextEditingController();
 
   void _toggleComments() {
     setState(() {
@@ -28,6 +33,64 @@ class _ImageViewModalState extends State<ImageViewModal> {
       _showText = false;
       _showShortCode = false;
     });
+  }
+
+  @override
+  void dispose() {
+    _commentController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    final intent = consumePendingIntent();
+    final postId = widget.shortCode ?? widget.imageUrl;
+    if (intent != null) {
+      if (intent.action == 'like' && intent.extras?['postId'] == postId) {
+        _toggleLike();
+      } else if (intent.action == 'comment' && intent.extras?['postId'] == postId) {
+        final text = intent.extras?['comment'];
+        if (text != null) {
+          _postComment(text);
+        }
+      }
+    }
+  }
+
+  Future<void> _toggleLike() async {
+    final postId = widget.shortCode ?? widget.imageUrl;
+    await guardWrite(context, () async {
+      final user = FirebaseAuth.instance.currentUser!;
+      final docId = '${postId}_${user.uid}';
+      final doc = FirebaseFirestore.instance.collection('likes').doc(docId);
+      final snap = await doc.get();
+      if (snap.exists) {
+        await doc.delete();
+        if (mounted) setState(() => _isLiked = false);
+      } else {
+        await doc.set({
+          'postId': postId,
+          'uid': user.uid,
+          'createdAt': FieldValue.serverTimestamp(),
+        });
+        if (mounted) setState(() => _isLiked = true);
+      }
+    }, action: 'like', extras: {'postId': postId});
+  }
+
+  Future<void> _postComment(String text) async {
+    final postId = widget.shortCode ?? widget.imageUrl;
+    await guardWrite(context, () async {
+      final user = FirebaseAuth.instance.currentUser!;
+      await FirebaseFirestore.instance.collection('comments').add({
+        'postId': postId,
+        'uid': user.uid,
+        'text': text,
+        'createdAt': FieldValue.serverTimestamp(),
+      });
+      _commentController.clear();
+    }, action: 'comment', extras: {'postId': postId, 'comment': text});
   }
 
   void _toggleText() {
@@ -58,7 +121,7 @@ class _ImageViewModalState extends State<ImageViewModal> {
             children: [
               IconButton(
                 icon: Icon(_isLiked ? Icons.favorite : Icons.favorite_border),
-                onPressed: () => setState(() => _isLiked = !_isLiked),
+                onPressed: _toggleLike,
               ),
               IconButton(
                 icon: const Icon(Icons.comment),
@@ -78,12 +141,28 @@ class _ImageViewModalState extends State<ImageViewModal> {
           ),
           Visibility(
             visible: _showComments,
-            child: const Padding(
-              padding: EdgeInsets.all(8.0),
-              child: TextField(
-                decoration: InputDecoration(
-                  hintText: 'leave a comment...',
-                ),
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _commentController,
+                      decoration: const InputDecoration(
+                        hintText: 'leave a comment...',
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.send),
+                    onPressed: () {
+                      final text = _commentController.text.trim();
+                      if (text.isNotEmpty) {
+                        _postComment(text);
+                      }
+                    },
+                  ),
+                ],
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- implement ReturnIntent and guardWrite for redirecting unauthenticated writes to auth flow
- add full-screen AuthPage with login/register toggle
- gate like and comment actions with guardWrite and auto resume after auth

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c0ddcc080832bb13ff38808ccfe03