### PR TITLE
Handle missing settings in auth pages

### DIFF
--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -23,38 +23,39 @@ class LoginPage extends StatelessWidget {
             if (snapshot.connectionState == ConnectionState.waiting) {
               return const Center(child: CircularProgressIndicator());
             }
+
+            // Base login widget used when remote settings are missing
+            final loginUi = Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.1),
+                    spreadRadius: 1,
+                    blurRadius: 5,
+                    offset: const Offset(0, 3),
+                  ),
+                ],
+              ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(12.0),
+                child: LoginWidget(onTap: onTap),
+              ),
+            );
+
             if (!snapshot.hasData || !snapshot.data!.exists) {
-              return const Center(child: Text('Settings not found.'));
+              // If settings aren't available yet, still show the login form
+              return Center(child: loginUi);
             }
 
             final data = snapshot.data!.data() as Map<String, dynamic>;
             final shortCode = data['login_zine_shortcode'] as String?;
             if (shortCode == null) {
-              return const Center(child: Text('No login zine configured.'));
+              // Fallback to plain login when no shortcode is configured
+              return Center(child: loginUi);
             }
 
-            return FanzineGridView(
-              shortCode: shortCode,
-              uiWidget: Container(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(12),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.1),
-                      spreadRadius: 1,
-                      blurRadius: 5,
-                      offset: const Offset(0, 3),
-                    ),
-                  ],
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(12.0),
-                  child: LoginWidget(
-                    onTap: onTap,
-                  ),
-                ),
-              ),
-            );
+            return FanzineGridView(shortCode: shortCode, uiWidget: loginUi);
           },
         ),
       ),

--- a/lib/pages/register_page.dart
+++ b/lib/pages/register_page.dart
@@ -22,36 +22,37 @@ class RegisterPage extends StatelessWidget {
             if (snapshot.connectionState == ConnectionState.waiting) {
               return const Center(child: CircularProgressIndicator());
             }
+
+            // Base register widget shown when remote settings are unavailable
+            final registerUi = Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.1),
+                    spreadRadius: 1,
+                    blurRadius: 5,
+                    offset: const Offset(0, 3),
+                  ),
+                ],
+              ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(12.0),
+                child: RegisterWidget(onTap: onTap),
+              ),
+            );
+
             if (!snapshot.hasData || !snapshot.data!.exists) {
-              return const Center(child: Text('Settings not found.'));
+              return Center(child: registerUi);
             }
+
             final data = snapshot.data!.data() as Map<String, dynamic>;
             final shortCode = data['register_zine_shortcode'] as String?;
             if (shortCode == null) {
-              return const Center(child: Text('No register zine configured.'));
+              return Center(child: registerUi);
             }
-            return FanzineGridView(
-              shortCode: shortCode,
-              uiWidget: Container(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(12),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.1),
-                      spreadRadius: 1,
-                      blurRadius: 5,
-                      offset: const Offset(0, 3),
-                    ),
-                  ],
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(12.0),
-                  child: RegisterWidget(
-                    onTap: onTap,
-                  ),
-                ),
-              ),
-            );
+
+            return FanzineGridView(shortCode: shortCode, uiWidget: registerUi);
           },
         ),
       ),


### PR DESCRIPTION
## Summary
- fall back to login/register form when Firestore settings are missing

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de7157dc4832b8e05b09a9b65b7d2