### PR TITLE
Fix login fallback when app settings missing

### DIFF
--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -24,13 +24,13 @@ class LoginPage extends StatelessWidget {
               return const Center(child: CircularProgressIndicator());
             }
             if (!snapshot.hasData || !snapshot.data!.exists) {
-              return const Center(child: Text('Settings not found.'));
+              return Center(child: LoginWidget(onTap: onTap));
             }
 
             final data = snapshot.data!.data() as Map<String, dynamic>;
             final shortCode = data['login_zine_shortcode'] as String?;
             if (shortCode == null) {
-              return const Center(child: Text('No login zine configured.'));
+              return Center(child: LoginWidget(onTap: onTap));
             }
 
             return FanzineGridView(

--- a/lib/pages/register_page.dart
+++ b/lib/pages/register_page.dart
@@ -23,12 +23,12 @@ class RegisterPage extends StatelessWidget {
               return const Center(child: CircularProgressIndicator());
             }
             if (!snapshot.hasData || !snapshot.data!.exists) {
-              return const Center(child: Text('Settings not found.'));
+              return Center(child: RegisterWidget(onTap: onTap));
             }
             final data = snapshot.data!.data() as Map<String, dynamic>;
             final shortCode = data['register_zine_shortcode'] as String?;
             if (shortCode == null) {
-              return const Center(child: Text('No register zine configured.'));
+              return Center(child: RegisterWidget(onTap: onTap));
             }
             return FanzineGridView(
               shortCode: shortCode,


### PR DESCRIPTION
## Summary
- display login form if app settings document is missing
- display register form if app settings document is missing

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689de7157dc4832b8e05b09a9b65b7d2