### PR TITLE
Gracefully handle missing app settings in auth pages

### DIFF
--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -20,40 +20,49 @@ class LoginPage extends StatelessWidget {
               .doc('main_settings')
               .snapshots(),
           builder: (context, snapshot) {
+            // While loading settings, show a progress indicator
             if (snapshot.connectionState == ConnectionState.waiting) {
               return const Center(child: CircularProgressIndicator());
             }
+
+            // Shared login UI that can be shown with or without settings
+            final loginUi = Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.1),
+                    spreadRadius: 1,
+                    blurRadius: 5,
+                    offset: const Offset(0, 3),
+                  ),
+                ],
+              ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(12.0),
+                child: LoginWidget(
+                  onTap: onTap,
+                ),
+              ),
+            );
+
+            // If settings are missing, fall back to basic login UI
             if (!snapshot.hasData || !snapshot.data!.exists) {
-              return const Center(child: Text('Settings not found.'));
+              return Center(child: loginUi);
             }
 
             final data = snapshot.data!.data() as Map<String, dynamic>;
             final shortCode = data['login_zine_shortcode'] as String?;
+
+            // If the shortcode is missing, still allow user to log in
             if (shortCode == null) {
-              return const Center(child: Text('No login zine configured.'));
+              return Center(child: loginUi);
             }
 
+            // Settings were found; show the configured fanzine grid view
             return FanzineGridView(
               shortCode: shortCode,
-              uiWidget: Container(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(12),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.1),
-                      spreadRadius: 1,
-                      blurRadius: 5,
-                      offset: const Offset(0, 3),
-                    ),
-                  ],
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(12.0),
-                  child: LoginWidget(
-                    onTap: onTap,
-                  ),
-                ),
-              ),
+              uiWidget: loginUi,
             );
           },
         ),

--- a/lib/pages/register_page.dart
+++ b/lib/pages/register_page.dart
@@ -19,38 +19,49 @@ class RegisterPage extends StatelessWidget {
               .doc('main_settings')
               .snapshots(),
           builder: (context, snapshot) {
+            // While loading settings, show progress
             if (snapshot.connectionState == ConnectionState.waiting) {
               return const Center(child: CircularProgressIndicator());
             }
-            if (!snapshot.hasData || !snapshot.data!.exists) {
-              return const Center(child: Text('Settings not found.'));
-            }
-            final data = snapshot.data!.data() as Map<String, dynamic>;
-            final shortCode = data['register_zine_shortcode'] as String?;
-            if (shortCode == null) {
-              return const Center(child: Text('No register zine configured.'));
-            }
-            return FanzineGridView(
-              shortCode: shortCode,
-              uiWidget: Container(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(12),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.1),
-                      spreadRadius: 1,
-                      blurRadius: 5,
-                      offset: const Offset(0, 3),
-                    ),
-                  ],
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(12.0),
-                  child: RegisterWidget(
-                    onTap: onTap,
+
+            // Shared register UI used as fallback when settings missing
+            final registerUi = Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.1),
+                    spreadRadius: 1,
+                    blurRadius: 5,
+                    offset: const Offset(0, 3),
                   ),
+                ],
+              ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(12.0),
+                child: RegisterWidget(
+                  onTap: onTap,
                 ),
               ),
+            );
+
+            // If settings are missing, allow registration without zine
+            if (!snapshot.hasData || !snapshot.data!.exists) {
+              return Center(child: registerUi);
+            }
+
+            final data = snapshot.data!.data() as Map<String, dynamic>;
+            final shortCode = data['register_zine_shortcode'] as String?;
+
+            // If no shortcode configured, show standalone register widget
+            if (shortCode == null) {
+              return Center(child: registerUi);
+            }
+
+            // Settings found; display fanzine grid view with register widget
+            return FanzineGridView(
+              shortCode: shortCode,
+              uiWidget: registerUi,
             );
           },
         ),


### PR DESCRIPTION
## Summary
- Avoid blocking auth when Firestore settings are missing
- Fall back to basic login or registration UI when shortcode not configured

## Testing
- ⚠️ `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689de7157dc4832b8e05b09a9b65b7d2