### PR TITLE
Use UID for Firestore user documents

### DIFF
--- a/lib/pages/fanzine_page.dart
+++ b/lib/pages/fanzine_page.dart
@@ -23,7 +23,7 @@ class FanzinePage extends StatelessWidget {
         child: StreamBuilder<DocumentSnapshot>(
           stream: FirebaseFirestore.instance
               .collection('Users')
-              .doc(currentUser.email)
+              .doc(currentUser.uid)
               .snapshots(),
           builder: (context, snapshot) {
             if (snapshot.connectionState == ConnectionState.waiting) {

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -42,11 +42,11 @@ class _ProfilePageState extends State<ProfilePage> {
       _isLoadingCurrentUser = true;
     });
     _currentUser = FirebaseAuth.instance.currentUser;
-    if (_currentUser != null && _currentUser!.email != null) {
+    if (_currentUser != null) {
       try {
         final userDoc = await FirebaseFirestore.instance
             .collection('Users')
-            .doc(_currentUser!.email)
+            .doc(_currentUser!.uid)
             .get();
         if (userDoc.exists && mounted) {
           final data = userDoc.data() as Map<String, dynamic>;
@@ -361,7 +361,7 @@ class _ProfilePageState extends State<ProfilePage> {
   Widget build(BuildContext context) {
     final currentUser = FirebaseAuth.instance.currentUser;
 
-    if (currentUser == null || currentUser.email == null) {
+    if (currentUser == null) {
       return Scaffold(
         backgroundColor: Colors.grey[200],
         body: const Center(

--- a/lib/widgets/edit_info_widget.dart
+++ b/lib/widgets/edit_info_widget.dart
@@ -50,7 +50,7 @@ class _EditInfoWidgetState extends State<EditInfoWidget> {
         emailController.text = currentUser!.email ?? 'No Email Found';
         final userDoc = await FirebaseFirestore.instance
             .collection('Users')
-            .doc(currentUser!.email)
+            .doc(currentUser!.uid)
             .get();
 
         if (userDoc.exists && mounted) {
@@ -64,7 +64,7 @@ class _EditInfoWidgetState extends State<EditInfoWidget> {
             firstNameController.text = data['firstName'] ?? ''; lastNameController.text = data['lastName'] ?? '';
           });
         } else if (mounted) {
-          print("User document not found in Firestore for ${currentUser!.email}");
+          print("User document not found in Firestore for ${currentUser!.uid}");
           setStateIfMounted(() { userNameController.text = currentUser!.displayName ?? ''; });
         }
       } catch (e) {
@@ -96,7 +96,7 @@ class _EditInfoWidgetState extends State<EditInfoWidget> {
           'city': cityController.text.trim(), 'state': stateController.text.trim(),
           'zipCode': zipController.text.trim(), 'country': countryController.text.trim(),
         };
-        await FirebaseFirestore.instance.collection('Users').doc(currentUser!.email).set(dataToUpdate, SetOptions(merge: true));
+        await FirebaseFirestore.instance.collection('Users').doc(currentUser!.uid).set(dataToUpdate, SetOptions(merge: true));
         _initialUsername = userNameController.text.trim();
         if(mounted) { displayMessageToUser("Profile Saved!", context); }
       } else { if(mounted) { displayMessageToUser("Error: No user logged in.", context); } }

--- a/lib/widgets/fanzine_widget.dart
+++ b/lib/widgets/fanzine_widget.dart
@@ -38,12 +38,12 @@ class _FanzineWidgetState extends State<FanzineWidget> {
     setState(() { _isLoadingData = true; _errorMessage = null; });
     if (currentUser != null) {
       try {
-        final userDoc = await FirebaseFirestore.instance.collection('Users').doc(currentUser!.email).get();
+        final userDoc = await FirebaseFirestore.instance.collection('Users').doc(currentUser!.uid).get();
         if (userDoc.exists && mounted) {
           final data = userDoc.data() as Map<String, dynamic>;
           setStateIfMounted(() { _username = data['username'] ?? 'N/A'; });
         } else if (mounted) {
-          print("User document not found for ${currentUser!.email}");
+          print("User document not found for ${currentUser!.uid}");
           setStateIfMounted(() { _username = 'N/A'; });
         }
       } catch (e) {

--- a/lib/widgets/profile_widget.dart
+++ b/lib/widgets/profile_widget.dart
@@ -39,7 +39,7 @@ class _ProfileWidgetState extends State<ProfileWidget> {
     setState(() { _isLoading = true; _errorMessage = null; });
     if (currentUser != null) {
       try {
-        final userDoc = await FirebaseFirestore.instance.collection('Users').doc(currentUser!.email).get();
+        final userDoc = await FirebaseFirestore.instance.collection('Users').doc(currentUser!.uid).get();
         if (userDoc.exists && mounted) {
           final data = userDoc.data() as Map<String, dynamic>;
           setState(() {
@@ -149,13 +149,13 @@ class _ProfileWidgetState extends State<ProfileWidget> {
                                     style: linkStyle,
                                     recognizer: TapGestureRecognizer()
                                       ..onTap = () {
-                                        if (currentUser?.uid == null && currentUser?.email == null) {
+                                        if (currentUser?.uid == null) {
                                           ScaffoldMessenger.of(context).showSnackBar(
                                             const SnackBar(content: Text('You must be logged in to upload images.')),
                                           );
                                           return;
                                         }
-                                        final userId = currentUser!.uid.isNotEmpty ? currentUser!.uid : currentUser!.email!;
+                                        final userId = currentUser!.uid;
                                         showDialog(
                                           context: context,
                                           barrierDismissible: false,

--- a/lib/widgets/register_widget.dart
+++ b/lib/widgets/register_widget.dart
@@ -71,15 +71,15 @@ class _RegisterWidgetState extends State<RegisterWidget> {
 
   // --- Create User Document Method ---
   Future<void> createUserDocument(UserCredential? userCredential) async {
-    if (userCredential?.user?.email != null) {
+    if (userCredential?.user != null) {
       final usersCollection = FirebaseFirestore.instance.collection('Users');
-      await usersCollection.doc(userCredential!.user!.email).set({
+      await usersCollection.doc(userCredential!.user!.uid).set({
         'email': userCredential.user!.email,
         'username': userNameController.text.trim(),
         'createdAt': FieldValue.serverTimestamp(),
       });
     } else {
-      print("Error: User credential or user email was null. Document not created.");
+      print("Error: User credential was null. Document not created.");
     }
   }
 


### PR DESCRIPTION
## Summary
- store user documents by FirebaseAuth UID while keeping email/username fields
- fetch current user data by UID across profile, fanzine, and related widgets

## Testing
- `apt-get install -y flutter` *(failed: Unable to locate package flutter)*
- `flutter analyze` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689eb5173d8c832b961690f9cf243a5d