### PR TITLE
Fix edit info route configuration

### DIFF
--- a/lib/utils/router.dart
+++ b/lib/utils/router.dart
@@ -90,11 +90,8 @@ final GoRouter router = GoRouter(
       },
     ),
     GoRoute(
-      path: '/edit-info/:fanzineId',
-      builder: (context, state) {
-        final fanzineId = state.pathParameters['fanzineId']!;
-        return EditInfoPage(fanzineId: fanzineId);
-      },
+      path: '/edit-info',
+      builder: (context, state) => const EditInfoPage(),
     ),
   ],
 );


### PR DESCRIPTION
## Summary
- update the edit info GoRouter route to match the page constructor and remove the unused fanzineId parameter

## Testing
- not run (flutter is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ec3a9c2060832b8f27cd25a6f49cb0